### PR TITLE
Endpoint shutdown gRPC when ctx is closed

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -87,8 +87,13 @@ func Listen(ctx context.Context, config Config) (ETCDConfig, error) {
 		log.Infof("Kine gRPC server is starting")
 		if err := grpcServer.Serve(listener); err != nil {
 			log.Errorf("Kine server shutdown: %v", err)
+			listener.Close()
 		}
+	}()
+
+	go func() {
 		<-ctx.Done()
+		log.Infof("Kine gRPC ctx exited stopping server")
 		grpcServer.Stop()
 		listener.Close()
 	}()


### PR DESCRIPTION
Split the shutdown of grpcServer from the grpcServer routine so the server is shutdown when the ctx is canceled.